### PR TITLE
Integrate uv for Server and GPU Worker containers

### DIFF
--- a/webRTC_external/Dockerfile
+++ b/webRTC_external/Dockerfile
@@ -1,10 +1,8 @@
-FROM python:3.9-slim
-
-# Copy the requirements file into the image
-COPY requirements.txt /app/requirements.txt
-
-# Install the requirements
-RUN pip install -r /app/requirements.txt
+# FROM python:3.9-slim-trixie
+# Install image w/ uv pre-installed
+# FROM ghcr.io/astral-sh/uv:python3.9-trixie-slim
+FROM python:3.12-slim-trixie
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Copy the just server.py into the image's root dir
 COPY server.py /app/server.py 
@@ -16,4 +14,4 @@ RUN chmod +x /app/server.py
 EXPOSE 8080 5000 3478/udp 3478/tcp 8001
 
 # Run the server.py on container startup
-ENTRYPOINT ["sh", "-c", "python3 /app/server.py"]
+ENTRYPOINT ["uv run", "python3 /app/server.py"]

--- a/webRTC_external/pyproject.toml
+++ b/webRTC_external/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "webrtc-external"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "asyncio>=4.0.0",
+    "boto3>=1.40.29",
+    "logging>=0.4.9.6",
+    "requests>=2.32.5",
+    "uuid>=1.30",
+    "uvicorn>=0.35.0",
+    "websockets>=15.0.1",
+]

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -1,5 +1,20 @@
+# /// script
+# dependencies = [
+#   "asyncio",
+#   "boto3",
+#   "requests",
+#   "threading",
+#   "time",
+#   "json",
+#   "logging",
+#   "websockets",
+#   "uvicorn",
+#   "uuid",
+#   "os",
+# ]
+# ///
+
 import asyncio
-from datetime import datetime, timedelta
 import boto3
 import requests
 import threading
@@ -7,15 +22,13 @@ import time
 import json
 import logging
 import websockets
-import time
 import uvicorn
 import uuid
 import os
 
-from aiortc import RTCPeerConnection, RTCSessionDescription
-from fastapi import FastAPI, Request, HTTPException, Header
+from datetime import datetime, timedelta
+from fastapi import FastAPI, HTTPException, Header
 from jose import jwt
-from urllib.request import urlopen
 
 # Setup logging.
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
This pull request updates the `webRTC_external` service to use a Python base image, adds a `pyproject.toml` for dependency management, and improves the container startup process by using `uv` for running the server. 

**Notes:**
- Switched the base image in `webRTC_external/Dockerfile` from `python:3.9-slim` to `python:3.12-slim-trixie` for an updated Python environment, and added copying of the `uv` binary from the Astral container for improved performance.
- Changed the container entrypoint to use `uv run` for starting `server.py`.
- Added a `pyproject.toml` with project metadata and explicit dependencies, enabling modern Python packaging and dependency management.
- Added a dependencies comment block at the top of `server.py` to document required packages, and cleaned up import statements for clarity and consistency. (Remove later, cannot run server script as uvx)