### PR TITLE
Add SSE Relay Server and Job/Filesystem API Endpoints

### DIFF
--- a/terraform/modules/signaling-server/main.tf
+++ b/terraform/modules/signaling-server/main.tf
@@ -38,6 +38,15 @@ resource "aws_security_group" "signaling" {
     description = "HTTP API"
   }
 
+  # Relay server port (SSE fanout for training logs and filesystem responses)
+  ingress {
+    from_port   = var.relay_port
+    to_port     = var.relay_port
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_cidr_blocks
+    description = "Relay server SSE"
+  }
+
   # SSH port
   ingress {
     from_port   = 22

--- a/terraform/modules/signaling-server/variables.tf
+++ b/terraform/modules/signaling-server/variables.tf
@@ -57,6 +57,12 @@ variable "http_port" {
   default     = 8001
 }
 
+variable "relay_port" {
+  description = "Relay server port (SSE fanout)"
+  type        = number
+  default     = 8081
+}
+
 # TURN Server Configuration
 variable "enable_turn" {
   description = "Enable coturn TURN server on the instance"

--- a/webRTC_external/Dockerfile
+++ b/webRTC_external/Dockerfile
@@ -14,8 +14,13 @@ COPY *.py /app/
 # Install dependencies
 RUN uv sync
 
-# Port exposed by the container, NOT computer (localhost), 8080 = websocket server, 3478 = TURN server
-EXPOSE 8080 5000 3478/udp 3478/tcp 8001
+# Port exposed by the container, NOT computer (localhost)
+# 8080 = websocket server, 8001 = HTTP API, 8081 = relay server, 3478 = TURN/STUN
+EXPOSE 8080 5000 3478/udp 3478/tcp 8001 8081
 
-# Run the server on container startup
-ENTRYPOINT ["uv", "run", "python3", "server.py"]
+# Copy entrypoint script
+COPY entrypoint.sh /app/
+RUN chmod +x /app/entrypoint.sh
+
+# Run both signaling server and relay server
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/webRTC_external/entrypoint.sh
+++ b/webRTC_external/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Start relay server in background, then signaling server in foreground
+uv run python3 relay.py &
+RELAY_PID=$!
+
+# If signaling server exits, also kill relay
+trap "kill $RELAY_PID 2>/dev/null" EXIT
+
+uv run python3 server.py

--- a/webRTC_external/pyproject.toml
+++ b/webRTC_external/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "boto3>=1.35.86",
     "fastapi>=0.115.6",
+    "httpx>=0.27.0",
     "pyotp>=2.9.0",
     "python-dotenv>=1.0.0",
     "python-jose[cryptography]>=3.3.0",

--- a/webRTC_external/relay.py
+++ b/webRTC_external/relay.py
@@ -93,22 +93,23 @@ async def stream(channel: str, request: Request):
     """
     queue: asyncio.Queue = asyncio.Queue(maxsize=256)
 
-    # Register subscriber
-    if channel not in subscribers:
-        subscribers[channel] = []
-    subscribers[channel].append(queue)
-
-    logger.info(
-        f"SSE subscriber connected to {channel} "
-        f"({len(subscribers[channel])} total)"
-    )
-
     async def event_generator():
         try:
-            # Replay buffered events
+            # Replay buffered events BEFORE registering for live updates
+            # to avoid duplicates from publish() pushing to queue during replay
             if channel in buffers:
-                for event in buffers[channel]:
+                for event in list(buffers[channel]):
                     yield f"data: {json.dumps(event)}\n\n"
+
+            # Now register for live events (after replay is done)
+            if channel not in subscribers:
+                subscribers[channel] = []
+            subscribers[channel].append(queue)
+
+            logger.info(
+                f"SSE subscriber connected to {channel} "
+                f"({len(subscribers[channel])} total)"
+            )
 
             # Stream live events
             while True:

--- a/webRTC_external/relay.py
+++ b/webRTC_external/relay.py
@@ -1,0 +1,159 @@
+"""SLEAP-RTC Relay Server.
+
+Lightweight SSE fanout server for training progress and filesystem responses.
+Accepts HTTP POST publishes and fans them out to subscribed browser SSE connections.
+Buffers recent events per channel for late-joining browsers.
+
+Channels:
+  - job_{hex}        : Training events (epoch metrics, status changes)
+  - worker:{peer_id} : Worker events (filesystem responses)
+
+Run: uvicorn relay:app --host 0.0.0.0 --port 8081
+"""
+
+import asyncio
+import json
+import logging
+import time
+from collections import deque
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [relay] %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+MAX_BUFFER = 200
+
+# Event buffers keyed by channel ID
+buffers: dict[str, deque] = {}
+
+# SSE subscribers: each gets an asyncio.Queue
+subscribers: dict[str, list[asyncio.Queue]] = {}
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Relay server starting on :8081")
+    yield
+    logger.info("Relay server shutting down")
+
+
+app = FastAPI(title="SLEAP-RTC Relay", lifespan=lifespan)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET", "POST"],
+    allow_headers=["*"],
+)
+
+
+@app.post("/publish/{channel}", status_code=204)
+async def publish(channel: str, request: Request):
+    """Publish an event to a channel.
+
+    Called by:
+      - Signaling server (localhost) for fs_list_res, job status
+      - Training process (HPC outbound) for epoch metrics
+    """
+    data = await request.json()
+    data["_ts"] = time.time()
+
+    # Buffer the event
+    if channel not in buffers:
+        buffers[channel] = deque(maxlen=MAX_BUFFER)
+    buffers[channel].append(data)
+
+    # Fan out to all subscribers
+    queues = subscribers.get(channel, [])
+    for queue in queues:
+        try:
+            queue.put_nowait(data)
+        except asyncio.QueueFull:
+            logger.warning(f"Subscriber queue full for channel {channel}, dropping event")
+
+    logger.info(
+        f"Published to {channel}: type={data.get('type', '?')} "
+        f"({len(queues)} subscribers)"
+    )
+    return Response(status_code=204)
+
+
+@app.get("/stream/{channel}")
+async def stream(channel: str, request: Request):
+    """SSE stream for a channel.
+
+    Called by dashboard browser. Replays buffered events, then streams live.
+    """
+    queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+
+    # Register subscriber
+    if channel not in subscribers:
+        subscribers[channel] = []
+    subscribers[channel].append(queue)
+
+    logger.info(
+        f"SSE subscriber connected to {channel} "
+        f"({len(subscribers[channel])} total)"
+    )
+
+    async def event_generator():
+        try:
+            # Replay buffered events
+            if channel in buffers:
+                for event in buffers[channel]:
+                    yield f"data: {json.dumps(event)}\n\n"
+
+            # Stream live events
+            while True:
+                # Check if client disconnected
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
+                    yield f"data: {json.dumps(event)}\n\n"
+                except asyncio.TimeoutError:
+                    # Send keepalive comment to prevent connection timeout
+                    yield ": keepalive\n\n"
+        finally:
+            # Cleanup subscriber
+            if channel in subscribers:
+                try:
+                    subscribers[channel].remove(queue)
+                except ValueError:
+                    pass
+                if not subscribers[channel]:
+                    del subscribers[channel]
+            logger.info(f"SSE subscriber disconnected from {channel}")
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@app.get("/health")
+async def health():
+    """Health check."""
+    return {
+        "status": "ok",
+        "channels": len(buffers),
+        "total_subscribers": sum(len(q) for q in subscribers.values()),
+    }
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8081)

--- a/webRTC_external/requirements.txt
+++ b/webRTC_external/requirements.txt
@@ -12,6 +12,9 @@ boto3==1.35.86
 # HTTP requests
 requests==2.32.3
 
+# Async HTTP client (signaling → relay forwarding)
+httpx>=0.27.0
+
 # JWT handling
 python-jose[cryptography]==3.3.0
 

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -2103,6 +2103,7 @@ class FsListRequest(BaseModel):
     peer_id: str
     path: str
     req_id: str
+    offset: int = 0
 
 
 class WorkerMessageRequest(BaseModel):
@@ -2239,6 +2240,7 @@ async def fs_list(
         "type": "fs_list_req",
         "req_id": req.req_id,
         "path": req.path,
+        "offset": req.offset,
     }))
 
     logging.info(f"[FS] List request for {req.path} forwarded to {req.peer_id}")

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -942,6 +942,7 @@ async def get_room_workers(room_id: str, authorization: str = Header(...)):
                     "account_key_id": metadata.get("_account_key_id"),
                     "token_id": metadata.get("_token_id"),
                     "worker_name": metadata.get("_worker_name"),
+                    "properties": metadata.get("properties", {}),
                 })
 
         return {"workers": workers, "count": len(workers)}
@@ -2104,6 +2105,12 @@ class FsListRequest(BaseModel):
     req_id: str
 
 
+class WorkerMessageRequest(BaseModel):
+    room_id: str
+    peer_id: str
+    message: dict
+
+
 def _get_worker_ws(room_id: str, peer_id: str):
     """Look up a worker's WebSocket from the in-memory room registry.
 
@@ -2236,6 +2243,28 @@ async def fs_list(
 
     logging.info(f"[FS] List request for {req.path} forwarded to {req.peer_id}")
     return {"status": "request_forwarded"}
+
+
+@app.post("/api/worker/message")
+async def worker_message(
+    req: WorkerMessageRequest,
+    authorization: str = Header(...),
+):
+    """Forward an arbitrary message to a worker via its WebSocket.
+
+    Generic message relay: dashboard sends a message dict, signaling server
+    validates auth + room membership, then pushes the message to the worker's
+    WebSocket. Used for use_worker_path, fs_get_mounts, and other worker
+    commands that don't need dedicated endpoints.
+    """
+    await _verify_room_membership(authorization, req.room_id)
+    ws = _get_worker_ws(req.room_id, req.peer_id)
+
+    await ws.send(json.dumps(req.message))
+
+    msg_type = req.message.get("type", "unknown")
+    logging.info(f"[MSG] Forwarded '{msg_type}' to {req.peer_id} in room {req.room_id}")
+    return {"status": "forwarded"}
 
 
 async def handle_register(websocket, message):
@@ -3203,6 +3232,12 @@ async def handle_client(websocket):
                     if job_id:
                         await forward_to_relay(job_id, data)
                         logging.info(f"[RELAY] Forwarded job_status for {job_id}: {data.get('status')}")
+
+                # Worker → Relay forwarding (path validation and video checks)
+                elif msg_type in ("worker_path_ok", "worker_path_error", "fs_check_videos_response"):
+                    if peer_id:
+                        await forward_to_relay(f"worker:{peer_id}", data)
+                        logging.info(f"[RELAY] Forwarded {msg_type} from {peer_id}")
 
                 else:
                     logging.warning(f"Unknown message type: {msg_type}")

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -3229,11 +3229,11 @@ async def handle_client(websocket):
                         await forward_to_relay(f"worker:{peer_id}", data)
                         logging.info(f"[RELAY] Forwarded fs_list_res from {peer_id}")
 
-                elif msg_type == "job_status":
+                elif msg_type in ("job_status", "job_progress"):
                     job_id = data.get("job_id")
                     if job_id:
                         await forward_to_relay(job_id, data)
-                        logging.info(f"[RELAY] Forwarded job_status for {job_id}: {data.get('status')}")
+                        logging.info(f"[RELAY] Forwarded {msg_type} for {job_id}")
 
                 # Worker → Relay forwarding (path validation and video checks)
                 elif msg_type in ("worker_path_ok", "worker_path_error", "fs_check_videos_response"):

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -2,6 +2,7 @@
 # dependencies = [
 #   "boto3",
 #   "fastapi",
+#   "httpx",
 #   "python-jose[cryptography]",
 #   "pyotp",
 #   "requests",
@@ -15,6 +16,7 @@ import base64
 import boto3
 import hashlib
 import hmac
+import httpx
 import requests
 import secrets
 import threading
@@ -173,6 +175,29 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# =============================================================================
+# Relay Server Integration
+# =============================================================================
+RELAY_URL = os.environ.get("RELAY_URL", "http://localhost:8081")
+
+async def forward_to_relay(channel: str, data: dict):
+    """Forward an event to the relay server for SSE fanout.
+
+    Args:
+        channel: Relay channel ID (job_id or "worker:{peer_id}")
+        data: Event data to publish
+    """
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                f"{RELAY_URL}/publish/{channel}",
+                json=data,
+                timeout=2.0,
+            )
+    except Exception as e:
+        logging.warning(f"[RELAY] Forward failed for {channel}: {e}")
 
 
 # =============================================================================
@@ -2057,6 +2082,162 @@ async def get_metrics():
     }
 
 
+# =============================================================================
+# Job Submission & Filesystem API (Dashboard → Signaling → Worker)
+# =============================================================================
+
+class JobSubmitRequest(BaseModel):
+    room_id: str
+    peer_id: str
+    config: dict
+
+
+class JobCancelRequest(BaseModel):
+    room_id: str
+    peer_id: str
+
+
+class FsListRequest(BaseModel):
+    room_id: str
+    peer_id: str
+    path: str
+    req_id: str
+
+
+def _get_worker_ws(room_id: str, peer_id: str):
+    """Look up a worker's WebSocket from the in-memory room registry.
+
+    Args:
+        room_id: Room containing the worker
+        peer_id: Peer ID of the worker
+
+    Returns:
+        WebSocket connection object
+
+    Raises:
+        HTTPException: If room/peer not found or peer is offline
+    """
+    room = ROOMS.get(room_id)
+    if not room:
+        raise HTTPException(status_code=404, detail="Room not found or no peers online")
+    peer = room["peers"].get(peer_id)
+    if not peer:
+        raise HTTPException(status_code=404, detail=f"Peer {peer_id} not found or offline")
+    ws = peer.get("websocket") if isinstance(peer, dict) else peer
+    if not ws:
+        raise HTTPException(status_code=404, detail=f"Peer {peer_id} has no active connection")
+    return ws
+
+
+async def _verify_room_membership(authorization: str, room_id: str) -> dict:
+    """Verify JWT and confirm user is a member of the room.
+
+    Args:
+        authorization: Authorization header value
+        room_id: Room to check membership for
+
+    Returns:
+        User claims dict with 'sub' and 'username'
+
+    Raises:
+        HTTPException: If auth fails or user is not a room member
+    """
+    user = get_user_from_auth_header(authorization)
+    membership = room_memberships_table.get_item(
+        Key={"user_id": user["sub"], "room_id": room_id}
+    )
+    if "Item" not in membership:
+        raise HTTPException(status_code=403, detail="Not a member of this room")
+    return user
+
+
+@app.post("/api/jobs/submit")
+async def submit_job(
+    req: JobSubmitRequest,
+    authorization: str = Header(...),
+):
+    """Submit a training job to a worker.
+
+    Dashboard POSTs config; signaling server forwards to worker via WebSocket.
+    Also publishes initial 'submitted' status to relay for SSE tracking.
+    """
+    user = await _verify_room_membership(authorization, req.room_id)
+    ws = _get_worker_ws(req.room_id, req.peer_id)
+
+    job_id = f"job_{uuid.uuid4().hex[:8]}"
+
+    # Push job assignment to worker via WebSocket
+    await ws.send(json.dumps({
+        "type": "job_assigned",
+        "job_id": job_id,
+        "config": req.config,
+        "submitted_by": user.get("username", user["sub"]),
+    }))
+
+    # Publish initial status to relay
+    await forward_to_relay(job_id, {
+        "type": "status",
+        "status": "submitted",
+        "job_id": job_id,
+        "worker_peer_id": req.peer_id,
+    })
+
+    logging.info(
+        f"[JOB] Submitted {job_id} to {req.peer_id} in room {req.room_id} "
+        f"by {user.get('username')}"
+    )
+    return {"job_id": job_id}
+
+
+@app.post("/api/jobs/{job_id}/cancel")
+async def cancel_job(
+    job_id: str,
+    req: JobCancelRequest,
+    authorization: str = Header(...),
+):
+    """Cancel a running training job.
+
+    Sends cancel request to worker. Worker kills the training subprocess
+    (not the worker container) and reports status back via WebSocket.
+    """
+    await _verify_room_membership(authorization, req.room_id)
+    ws = _get_worker_ws(req.room_id, req.peer_id)
+
+    # Push cancel to worker via WebSocket
+    await ws.send(json.dumps({
+        "type": "job_cancel",
+        "job_id": job_id,
+    }))
+
+    logging.info(f"[JOB] Cancel sent for {job_id} to {req.peer_id}")
+    return {"status": "cancel_sent"}
+
+
+@app.post("/api/fs/list")
+async def fs_list(
+    req: FsListRequest,
+    authorization: str = Header(...),
+):
+    """Request a directory listing from a worker's filesystem.
+
+    Pushes request to worker via WebSocket. Worker responds with fs_list_res
+    on its WS, which the signaling server forwards to relay for SSE delivery.
+    Dashboard matches the response by req_id.
+    """
+    await _verify_room_membership(authorization, req.room_id)
+    ws = _get_worker_ws(req.room_id, req.peer_id)
+
+    # Push filesystem request to worker via WebSocket
+    await ws.send(json.dumps({
+        "type": "fs_list_req",
+        "req_id": req.req_id,
+        "path": req.path,
+    }))
+
+    logging.info(f"[FS] List request for {req.path} forwarded to {req.peer_id}")
+    return {"status": "request_forwarded"}
+
+
 async def handle_register(websocket, message):
     """Handles the registration of a peer in a room w/ its websocket.
 
@@ -3010,6 +3191,18 @@ async def handle_client(websocket):
                         continue
 
                     await forward_message(sender_pid, target_pid, data)
+
+                # Worker → Relay forwarding (filesystem responses, job status)
+                elif msg_type == "fs_list_res":
+                    if peer_id:
+                        await forward_to_relay(f"worker:{peer_id}", data)
+                        logging.info(f"[RELAY] Forwarded fs_list_res from {peer_id}")
+
+                elif msg_type == "job_status":
+                    job_id = data.get("job_id")
+                    if job_id:
+                        await forward_to_relay(job_id, data)
+                        logging.info(f"[RELAY] Forwarded job_status for {job_id}: {data.get('status')}")
 
                 else:
                     logging.warning(f"Unknown message type: {msg_type}")


### PR DESCRIPTION
## Summary

Adds a standalone SSE relay server and three new signaling server endpoints to support dashboard-driven job submission, job cancellation, and filesystem browsing — without requiring direct WebRTC connections between the browser and HPC workers.

## Motivation

The current architecture requires a direct WebRTC data channel between the dashboard browser and each worker. This works on local networks but fails behind HPC NAT/firewall environments (symmetric NAT, no UDP, blocked STUN). After extensive debugging on the current `add-dashboard-job-submission` branch in sleap-RTC (8 of 22 commits were ICE/STUN fixes), we designed a relay-based architecture where all communication is outbound-only from workers, routing through two lightweight servers on the EC2 instance. See [`sleap-RTC/scratch/sleap-rtc-dashboard-architecture.md`](https://github.com/talmolab/sleap-rtc/blob/amick/add-dashboard-job-submission/scratch/sleap-rtc-dashboard-architecture.md) for the full architecture reference.

## Changes

### Relay Server (`relay.py` — new, :8081)
Standalone FastAPI app that accepts HTTP POST publishes and fans them out to browser SSE subscribers. Designed for two channel types:
- **`job_{id}`** — training process posts epoch metrics and status; dashboard subscribes for live monitoring
- **`worker:{peer_id}`** — signaling server posts filesystem responses; dashboard subscribes for directory listings

Features:
- In-memory deque buffer (max 200 events per channel) with replay on late-joining subscribers
- 30-second SSE keepalive to prevent connection timeouts
- CORS enabled for dashboard access

### Signaling Server Endpoints (`server.py` — modified)

| Endpoint | Purpose |
|----------|---------|
| `POST /api/jobs/submit` | Dashboard submits training config → signaling generates `job_id` → pushes `job_assigned` to worker via WS → publishes initial status to relay |
| `POST /api/jobs/{job_id}/cancel` | Dashboard requests cancel → signaling pushes `job_cancel` to worker via WS. Worker kills training subprocess only (stays connected and available). |
| `POST /api/fs/list` | Dashboard requests directory listing → signaling pushes `fs_list_req` to worker via WS. Worker responds with `fs_list_res` on WS → signaling forwards to relay → dashboard receives via SSE. |

All endpoints use existing JWT auth (`verify_sleap_jwt`) and validate room membership before routing.

### WebSocket Message Forwarding
Three message types handled in `handle_client()`:
- **`fs_list_res`** — worker filesystem response → forwarded to relay on channel `worker:{peer_id}`
- **`job_status`** — worker job status update → forwarded to relay on channel `{job_id}`
- **`job_progress`** — epoch-level training progress (train_begin, epoch_end, train_end) → forwarded to relay on channel `{job_id}` for live epoch/loss display in dashboard

### Deployment
- `entrypoint.sh` starts relay in background, signaling in foreground
- Dockerfile exposes port 8081
- Terraform security group updated with `relay_port` variable and ingress rule
- `httpx` added to dependencies for async signaling → relay forwarding

## Test Plan
- [x] Deploy to EC2 and verify both servers respond on health endpoints
- [x] Publish test events to relay, verify buffer and SSE replay
- [x] Subscribe to SSE stream, publish live events, verify real-time delivery
- [x] Verify no duplicate events on replay (fixed in second commit)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)