### PR TITLE
Add per-connection Heartbeat Ping for Stale Worker Detection

### DIFF
--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -3147,6 +3147,18 @@ def get_room(room_id: str):
     return doc
 
 
+async def _ping_loop(websocket, peer_id):
+    """Send periodic pings so workers can detect stale connections through Cloudflare."""
+    try:
+        while True:
+            await asyncio.sleep(30)
+            await websocket.send(json.dumps({"type": "ping"}))
+    except (websockets.exceptions.ConnectionClosed, asyncio.CancelledError):
+        pass
+    except Exception as e:
+        logging.warning(f"Ping loop error for {peer_id}: {e}")
+
+
 async def handle_client(websocket):
     """Handles incoming messages between peers to facilitate exchange of SDP & ICE candidates.
 
@@ -3166,6 +3178,7 @@ async def handle_client(websocket):
     """
 
     peer_id = None  # Track for cleanup
+    ping_task = None
 
     try:
         async for message in websocket:
@@ -3178,6 +3191,8 @@ async def handle_client(websocket):
                 if msg_type == "register":
                     await handle_register(websocket, data)
                     peer_id = data.get('peer_id')
+                    if ping_task is None:
+                        ping_task = asyncio.create_task(_ping_loop(websocket, peer_id))
 
                 # NEW: Peer discovery
                 elif msg_type == "discover_peers":
@@ -3264,6 +3279,8 @@ async def handle_client(websocket):
         logging.error(f"Error handling client {peer_id}: {e}")
 
     finally:
+        if ping_task:
+            ping_task.cancel()
         # Clean up peer on disconnect
         if peer_id:
             await cleanup_peer(peer_id)

--- a/webRTC_external/server.py
+++ b/webRTC_external/server.py
@@ -3152,6 +3152,7 @@ async def _ping_loop(websocket, peer_id):
     try:
         while True:
             await asyncio.sleep(30)
+            logging.info(f"[PING] Sending ping to {peer_id}")
             await websocket.send(json.dumps({"type": "ping"}))
     except (websockets.exceptions.ConnectionClosed, asyncio.CancelledError):
         pass


### PR DESCRIPTION
## Summary
- Server sends `{"type": "ping"}` every 30s to each registered peer
- Workers use this to detect stale connections through Cloudflare, which keeps WebSocket connections alive after a server restart
- Per-connection background task, cancelled on disconnect

## Context
Companion to [sleap-RTC#amick/worker-try-reconnect](https://github.com/talmolab/sleap-rtc/tree/amick/worker-try-reconnect) which adds the worker-side watchdog.

## Test plan
- [ ] Deploy to test instance, verify pings appear in worker logs
- [ ] Restart signaling server, verify worker detects stale connection within ~90s and reconnects

🤖 Generated with [Claude Code](https://claude.com/claude-code)